### PR TITLE
[fix] can parse special metric and add test

### DIFF
--- a/service/Metrics.go
+++ b/service/Metrics.go
@@ -8,6 +8,16 @@ var Special_Metric = map[string]bool{
 	"change_request_age":                 true,
 }
 
+var Special_Value = []string{
+	"avg",
+	"levels",
+	"quantile_0",
+	"quantile_1",
+	"quantile_2",
+	"quantile_3",
+	"quantile_4",
+}
+
 var Metrics = [...]string{
 	"openrank",
 	"activity",

--- a/service/getrepoinfoservice.go
+++ b/service/getrepoinfoservice.go
@@ -70,8 +70,18 @@ func GetCertainRepoInfo(repo, metric, month string) RepoInfo {
 
 	data := make(map[string](map[string]interface{}))
 
-	for k, v := range repoInfo.data {
-		data[k] = map[string]interface{}{month: v[month]}
+	if Special_Metric[metric] {
+		for k, v := range repoInfo.data {
+			dataMap := make(map[string]interface{})
+			for _, val := range Special_Value {
+				dataMap[val] = v[val].(map[string]interface{})[month]
+			}
+			data[k] = map[string]interface{}{month: dataMap}
+		}
+	} else {
+		for k, v := range repoInfo.data {
+			data[k] = map[string]interface{}{month: v[month]}
+		}
 	}
 
 	repoInfo.data = data

--- a/service/getrepoinfoservice_test.go
+++ b/service/getrepoinfoservice_test.go
@@ -31,6 +31,16 @@ func TestGetCertainRepo(t *testing.T) {
 	}
 }
 
+func TestGetCertainRepoSpecial(t *testing.T) {
+	avg := 149.29
+	month := "2020-08"
+	metric := "issue_response_time"
+	a := GetCertainRepoInfo("X-lab2017/open-digger", metric, month)
+	if a.data["issue_response_time"][month].(map[string]interface{})["avg"] != avg {
+		t.Errorf("get Certain Repo Special fail")
+	}
+}
+
 func TestGetRepoInfoOfMonth(t *testing.T) {
 	var result float32
 	result = 4.5


### PR DESCRIPTION
fix #19 
针对特殊的metric，如issue_response_time，将对应的value type修改为map[string]interface{}, 通过data[metric][month]访问
map[avg:149.29 levels:[6 0 0 1] quantile_0:0 quantile_1:0 quantile_2:0 quantile_3:0 quantile_4:1045]
