### PR TITLE
[feat] 申请在getrepoinfoservice服务中实现对于9个特殊metric string的解析

### DIFF
--- a/service/getrepoinfoservice.go
+++ b/service/getrepoinfoservice.go
@@ -19,7 +19,7 @@ type SpecialDataStructure struct {
 	issueResponseTimeAvg   map[string]float32     //key为日期
 	issueResponseTimeLevel map[string]([]float32) //key为日期
 
-	//剩下这几个也不知道获取了什么，像issueResponseTime一样拆分吧
+	//剩下这几个也不知道获取了什么，像issueResponseTime一样拆分吧，如果有同类项可以写一个struct，然后map[string](NewStruct)
 	//issueResolutionDuration
 	//changeRequestResponseTime
 	//changeRequestResolutionDuration


### PR DESCRIPTION
<img width="482" alt="image" src="https://github.com/wengsy150943/OpenSODAExcitingT2/assets/57783174/ef8fc7f3-01a7-4253-857c-2c356aa370f3">
是否能将9个metric string的返回值单独在repoinfo处处理，转成string再反序列化成嵌套map明显没有从json数据转成需要的嵌套map方便 @YinZheng-Sun @lh123cha 